### PR TITLE
update wemo plugin link

### DIFF
--- a/src/app/pages/features/features.component.html
+++ b/src/app/pages/features/features.component.html
@@ -26,7 +26,7 @@
           </a>
         </li>
         <li>
-          <a href="https://github.com/bwp91/homebridge-platform-wemo#readme" target="_blank">
+          <a href="https://github.com/bwp91/homebridge-wemo#readme" target="_blank">
             Belkin Wemo
           </a>
         </li>


### PR DESCRIPTION
`homebridge-platform-wemo` is now `homebridge-wemo`