### PR TITLE
Accessibility and SEO improvements

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -1,4 +1,4 @@
-<footer class="d-flex flex-column mt-auto w-100 pr-1 pl-1">
+<footer class="d-flex flex-column mt-auto w-100 pr-1 pl-1 homebridge-purple-200">
   <p>
     Homebridge is brought to you by thousands of plugin developers, dozens of core contributors, <a
       href="https://twitter.com/pieceofsummer">@pieceofsummer</a> who reverse-engineered HomeKit, <a

--- a/src/app/pages/features/features.component.html
+++ b/src/app/pages/features/features.component.html
@@ -43,7 +43,7 @@
       </ul>
     </div>
     <div class="col-md-6 text-center">
-      <img src="assets/images/logos.png" width="80%">
+      <img src="assets/images/logos.png" alt="" width="80%">
     </div>
   </div>
 
@@ -81,13 +81,13 @@
       </p>
     </div>
     <div class="col-md-6 text-center">
-      <img src="assets/images/homekit-ecosystem.png" width="100%">
+      <img src="assets/images/homekit-ecosystem.png" alt="" width="100%">
     </div>
   </div>
 
   <div class="row mt-2 p-5 section-block" style="background-color: #f8f7fa;">
     <div class="col-md-6 text-center">
-      <img src="assets/images/homebridge-ui.png" width="100%">
+      <img src="assets/images/homebridge-ui.png" alt="" width="100%">
     </div>
     <div class="col-md-6">
       <h3>Simple user interface</h3>
@@ -157,7 +157,7 @@
       </ul>
     </div>
     <div class="col-md-6 text-center">
-      <img class="RaspberryPi mt-2" src="assets/images/raspberry-pi.svg" width="80%">
+      <img class="RaspberryPi mt-2" src="assets/images/raspberry-pi.svg" alt="" width="80%">
     </div>
   </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <title>Homebridge</title>
   <base href="/">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 
   <link rel="apple-touch-icon" sizes="180x180" href="assets/images/apple-touch-icon.png">

--- a/src/scss/base/colors.scss
+++ b/src/scss/base/colors.scss
@@ -9,6 +9,7 @@
 $homebridge-white: #fff;
 
 // Purple
+$homebridge-purple-200: #c084ff;
 $homebridge-purple-300: #8a36e3; // Base colour
 $homebridge-purple-400: #3d1a63;
 $homebridge-purple-500: #2d114c;

--- a/src/scss/base/typography.scss
+++ b/src/scss/base/typography.scss
@@ -9,6 +9,7 @@
   font-style: normal;
   font-weight: 300;
   src: local(".SFNSText-Light"), local(".HelveticaNeueDeskInterface-Light"), local(".LucidaGrandeUI"), local("Ubuntu Light"), local("Segoe UI Light"), local("Roboto-Light"), local("DroidSans"), local("Tahoma");
+  font-display: swap;
 }
 
 $default-font-family: "din-2014", system, sans-serif;
@@ -40,4 +41,8 @@ h5 {
 a {
   color: $homebridge-purple-300;
   text-decoration: none;
+}
+
+.homebridge-purple-200 a {
+  color: $homebridge-purple-200;
 }


### PR DESCRIPTION
- Images have `[alt]` attributes, even empty are better for accessibility
- Background and foreground colours have a sufficient contrast ratio. There was a problem in footer, now links have 7.09 contrast ratio
- Added `font-display: swap;` - Text remains visible during webfont load


In Lighthouse test we have improvements:
in Accessibility by from 80 to 98 points
in SEO by from 88 to 96 points
![ 2022-10-30 at 14 38 22](https://user-images.githubusercontent.com/1818155/198881698-090408e5-af87-4a0f-b147-e599c43ce7b6.png)
