### PR TITLE
Fix homepage dead link to homebridge-ring

### DIFF
--- a/src/app/pages/features/features.component.html
+++ b/src/app/pages/features/features.component.html
@@ -9,7 +9,7 @@
       <p>Some of the most popular plugins include:</p>
       <ul>
         <li>
-          <a href="https://github.com/dgreif/ring/tree/master/homebridge#readme" target="_blank">Ring</a>
+          <a href="https://github.com/dgreif/ring/tree/main/packages/homebridge-ring#readme" target="_blank">Ring</a>
         </li>
         <li>
           <a href="https://github.com/chrisjshull/homebridge-nest#readme" target="_blank">Nest</a> &amp;


### PR DESCRIPTION
## :recycle: Current situation

I opened https://homebridge.io/, clicked on the ring plugin link. The link points to a 404 on github.

## :bulb: Proposed solution

The link is fixed. 

## :gear: Release Notes

Fix homepage dead link to  homebridge-ring.

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
